### PR TITLE
Add namespace to `kubectl describe prometheus` command

### DIFF
--- a/data/part-4/2-messaging-systems.md
+++ b/data/part-4/2-messaging-systems.md
@@ -177,7 +177,7 @@ $ kubectl -n prometheus get prometheus
   NAME                                    VERSION   REPLICAS   AGE
   kube-prometheus-stack-1602-prometheus   v2.18.2   1          39h
 
-$ kubectl describe prometheus kube-prometheus-stack-1602-prometheus
+$ kubectl describe prometheus -n prometheus kube-prometheus-stack-1602-prometheus
 ...
  Service Monitor Selector:
     Match Labels:


### PR DESCRIPTION
Specify namespace for `kubectl describe prometheus` command, otherwise would get 
```
Error from server (NotFound): prometheuses.monitoring.coreos.com "kube-prometheus-stack-1605-prometheus" not found
```