### PR TITLE
Update Helm stable charts

### DIFF
--- a/data/part-2/5-monitoring.md
+++ b/data/part-2/5-monitoring.md
@@ -22,7 +22,7 @@ Installation instructions are [here](https://helm.sh/docs/intro/install/). After
 
 ```console
 $ helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-$ helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+$ helm repo add stable https://charts.helm.sh/stable
 ```
 
 And after that we can install [kube-prometheus-stack](https://artifacthub.io/packages/helm/prometheus-community/kube-prometheus-stack). By default this would put everything to the default namespace.


### PR DESCRIPTION
I get the following warnings when using url from course material.

```
WARNING: "kubernetes-charts.storage.googleapis.com" is deprecated for "stable" and will be deleted Nov. 13, 2020.
WARNING: You should switch to "https://charts.helm.sh/stable"
```

New url is also in official [docs](https://helm.sh/docs/intro/quickstart/#initialize-a-helm-chart-repository) 