### PR TITLE
Change url to deployment.yaml

### DIFF
--- a/data/part-1/4-introduction-to-storage.md
+++ b/data/part-1/4-introduction-to-storage.md
@@ -30,7 +30,7 @@ App 1 will check if /usr/src/app/files/image.jpg exists and if not download a ra
 
 App 2 will check for /usr/src/app/files/image.jpg and show it if it is available.
 
-They share a deployment so that both of them are inside the same pod. My version available [here](https://github.com/kubernetes-hy/material-example/tree/master/app3). The example includes ingress and service to access the application.
+They share a deployment so that both of them are inside the same pod. My version available [here](https://github.com/kubernetes-hy/material-example/blob/616b241e2e9a76e7cecabb47384f67c874c05f80/app3/manifests/deployment.yaml). The example includes ingress and service to access the application.
 
 **deployment.yaml**
 


### PR DESCRIPTION
This way the reader doesn't get confused by the 'need' to implement persistent storages just yet