### PR TITLE
Escape underscores in exercise 4.03

### DIFF
--- a/data/part-4/1-update-strategies-and-prometheus.md
+++ b/data/part-4/1-update-strategies-and-prometheus.md
@@ -363,7 +363,7 @@ $ kubectl -n prometheus port-forward prometheus-kube-prometheus-stack-1602-prome
     </tbody>
   </table>
 
-  Query for "kube_pod_info" should have the required fields to filter through. See [documentation](https://prometheus.io/docs/prometheus/latest/querying/basics/) for help with querying.
+  Query for "kube\_pod\_info" should have the required fields to filter through. See [documentation](https://prometheus.io/docs/prometheus/latest/querying/basics/) for help with querying.
 
 </exercise>
 


### PR DESCRIPTION
The underscores in the text "kube\_pod\_info" are not escaped which causes them to render as "kube<i>pod</i>info", which is probably not intended.