### PR TITLE
fix: flux link

### DIFF
--- a/data/part-4/3-GitOps.md
+++ b/data/part-4/3-GitOps.md
@@ -47,7 +47,7 @@ To get started we'll need to get a GITHUB_TOKEN. You can follow the GitHub [guid
 Next step isn't a surprise at this point. As with most tools this time we will need to install the Flux CLI.
 
 ```console
-$ curl -s https://toolkit.fluxcd.io/install.sh | sudo bash
+$ curl -s https://fluxcd.io/install.sh | sudo bash
 ```
 
 or if that doesn't work read [installation guide](https://toolkit.fluxcd.io/guides/installation/).


### PR DESCRIPTION
When using `curl -s https://toolkit.fluxcd.io/install.sh | sudo bash` the following error occurs `bash: line 1: Redirecting: command not found`.

When running `curl -I https://toolkit.fluxcd.io/install.sh` the HTTP status code is 301 with message `Redirecting to https://fluxcd.io/install.sh`.

Following https://fluxcd.io/docs/installation/ guide the installation url is `https://fluxcd.io/install.sh`. This is now updated and working.