### PR TITLE
Update outdated cluster version in part 3.1

### DIFF
--- a/data/part-3/1-introduction-to-gke.md
+++ b/data/part-3/1-introduction-to-gke.md
@@ -136,7 +136,7 @@ $ gcloud container clusters delete dwk-cluster --zone=europe-north1-b
 
 And when resuming progress create the cluster back.
 ```console
-$ gcloud container clusters create dwk-cluster --zone=europe-north1-b --cluster-version=1.22
+$ gcloud container clusters create dwk-cluster --zone=europe-north1-b --cluster-version=1.29
 ```
 
 Closing the cluster will also remove everything you've deployed on the cluster. So if you decide to take a days long break during an exercise, you may have to redo it. Thankfully we are using a declarative approach so continuing progress will only require you to apply the yamls.


### PR DESCRIPTION
Version 1.29 is used in preceding commands:
https://github.com/kubernetes-hy/kubernetes-hy.github.io/blob/d32f53fa40731e7f98df9a9ad7981bf536005ba9/data/part-3/1-introduction-to-gke.md?plain=1#L56