### PR TITLE
Fix file `yaml` references in chapter 4.3

### DIFF
--- a/data/part-4/3-GitOps.md
+++ b/data/part-4/3-GitOps.md
@@ -277,7 +277,7 @@ spec:
 ```
 
 
-The **base/kustomize.yaml** is simple:
+The **base/kustomization.yaml** is simple:
 
 ```yaml
 resources:
@@ -297,7 +297,7 @@ spec:
 
 So only parts that are different are defined.
 
-The **overlays/prod/kustomize.yaml** looks like following:
+The **overlays/prod/kustomization.yaml** looks like following:
 
 ```yaml
 resources:
@@ -314,7 +314,7 @@ images:
 
 So it refers to the base and [patches](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/patches/) that with the above deployment that sets the number of replicas to 3.
 
-The **overlays/staging/kustomize.yaml** just sets the image:
+The **overlays/staging/kustomization.yaml** just sets the image:
 
 ```yaml
 resources:

--- a/data/part-4/3-GitOps.md
+++ b/data/part-4/3-GitOps.md
@@ -284,7 +284,7 @@ resources:
 - deployment.yaml
 ```
 
-The production environment refines the base by changing the replica count to 3. **overlays/prod/kustomize.yaml** looks like this:
+The production environment refines the base by changing the replica count to 3. The **overlays/prod/deployment.yaml** looks like this:
 
 ```yaml
 apiVersion: apps/v1


### PR DESCRIPTION
I believe to have found the following two errors in chapter 4.3 (GitOps):

- We refer to a `kustomize.yaml` whereas the file is named `kustomization.yaml` in the filetree. 
- We refer to the `overlays/prod/kustomize.yaml` when we meant `overlays/prod/deployment.yaml`, judging by the following file content.  

Let me know if there are other changes needed!