### PR TITLE
Updated part 0 to reflect indefinte status of course

### DIFF
--- a/data/part-0/index.md
+++ b/data/part-0/index.md
@@ -17,7 +17,7 @@ The course material is written using Mac, so some instructions may lack platform
 
 ## Completion and grading ##
 
-To complete the course, complete exercises in parts 1-5 before the deadline that is 31st January 2025.
+To complete the course, complete exercises in parts 1-5 and mark your completion in the portal, following the instructions provided below.
 
 The total workload of the course is about 100 hours depending on your background.
 


### PR DESCRIPTION
Since the course is open indefinitely, there is no need for a deadline.  Hence removed deadline and directed user to submission instructions.